### PR TITLE
Added android:exported="true" to the AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mawaqit.admin">
-  
+
      <!-- Restrict app for tablets and TVs only -->
     <supports-screens android:smallScreens="false"
                     android:normalScreens="false"
@@ -37,7 +37,8 @@
       android:theme="@style/LaunchTheme"
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
       android:hardwareAccelerated="true"
-      android:windowSoftInputMode="adjustResize">
+      android:windowSoftInputMode="adjustResize"
+      android:exported="true">
       <!-- Specifies an Android theme to apply to this Activity as soon as
            the Android process has started. This theme is visible to the user
            while the Flutter UI initializes. After that, this theme continues


### PR DESCRIPTION
Fixed the missing exported="true" error message when uploading the .aab build through the Google Play console.
(Android 12 compatibility) 
Close #19 